### PR TITLE
added audio context

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,9 @@ async function _getAudioBuffer(blobData) {
 
     const arrayBuffer = await response.arrayBuffer();
 
-    const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer)
+    const audioContext = new AudioContext();
+
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer)
 
     return audioBuffer;
 }


### PR DESCRIPTION
`line 79:  const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer)`

was giving an error that decodeAudioData cannot read properties of undefined.
Adding an audio context fixed the error for me.
I found this library useful, so wanted to help fix this minor issue. :)