### PR TITLE
Fix issue #3: Blob data not converted to audio buffer (wavBlobUtil.js)

### DIFF
--- a/wavBlobUtil.js
+++ b/wavBlobUtil.js
@@ -68,11 +68,7 @@ function _writeAudioBufferToArray(
 
 // Converts the Blob data to AudioBuffer
 async function _getAudioBuffer(blobData, contextOptions = undefined) {
-    let blob = blobData;
-
-    if (!(blob instanceof Blob)) blob = new Blob([blobData]);
-
-    const url = URL.createObjectURL(blob);
+    const url = URL.createObjectURL(new Blob(blobData, {type: 'audio/webm' }));
 
     const response = await fetch(url);
 


### PR DESCRIPTION
When recording audio with mediaRecorder API, the method _getAudioBuffer does not accept the Blob. We can also pass the blob type to the method so (if) the new blob is created, it is created dynamically for audio/webm or cideo/webm. 